### PR TITLE
[fix] #8 - 로그인 role 캐싱 오류 해결

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -9,6 +9,11 @@
     <app-button label="내 매장 관리" variant="tinted-bordered" size="full" (click)="goToManagerPage()"></app-button>
   </ng-container> -->
 
+  <!-- 캐싱 테스트 코드 -->
+  <!-- <ng-container *ngIf="true">
+    <p>role 값: {{ role }}</p>
+  </ng-container> -->
+
   <ng-container *ngIf="role === 'ADMIN'">
     <ion-button expand="block" (click)="goToManagerRequestPage()">
       매니저 요청 페이지 (관리자용)

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -29,6 +29,7 @@ export class HomePage implements OnInit {
 
   async signOut() {
     this.authService.signOut()
+    this.role = null // 로그아웃 시 role 초기화
     await this.router.navigate(['/signin'])
   }
 
@@ -40,7 +41,18 @@ export class HomePage implements OnInit {
     } else {
       localStorage.removeItem('homePageRefreshed')
       this.initMiniMap() // 새로고침 후 로직 실행
+
+      // 기존 role 읽기 유지
       this.role = this.authService.getUserRole()
+
+      // 로그인 상태 변화 시마다 role 업데이트
+      this.isLoggedIn$.subscribe((isLoggedIn) => {
+        if (isLoggedIn) {
+          this.role = this.authService.getUserRole()
+        } else {
+          this.role = null
+        }
+      })
     }
   }
 

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -35,6 +35,7 @@ export class AuthService {
 
   signOut(): void {
     localStorage.removeItem('accessToken') // 로그아웃 시 토큰 삭제
+    localStorage.removeItem('homePageRefreshed')
     this.isLoggedInSubject.next(false)
   }
 


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #8 
<br/>


## 작업 내용
- HomePage에서 role 값을 읽을 때 authService를 통해 즉시 갱신되도록 로직 수정
- 기존 새로고침 후에도 role이 이전 값으로 남아 있던 문제 해결

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 리뷰어가 알면 좋을 추가적인 내용
- 현재는 authService.getUserRole() 호출 시 항상 최신 role을 가져오도록 동작
